### PR TITLE
refactor: rename some 'event' symbols to 'session'

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { createQueryClient } from "./queries/query-client";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { Layout } from "./Layout";
 import { EventContext } from "./context/EventContext";
-import { EventsSchedule } from "./pages/EventsSchedule";
+import { SessionsSchedule } from "./pages/SessionsSchedule";
 import { ServicesSchedule } from "./pages/ServicesSchedule";
 import { Speakers } from "./pages/Speakers";
 
@@ -17,7 +17,7 @@ export const App: React.FC = () =>
             <EventContext.Provider value="">
                 <Routes>
                     <Route path="/" element={<Layout />}>
-                        <Route path="events" element={<EventsSchedule/>} />
+                        <Route path="sessions" element={<SessionsSchedule/>} />
                         <Route path="services" element={<ServicesSchedule/>} />
                         <Route path="speakers" element={<Speakers/>} />
                     </Route>

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 
 export const Layout: React.FC = () => <>
     <nav>
-        <Link to="/events">Events</Link> |
+        <Link to="/sessions">Panels &amp; Events</Link> |
         <Link to="/services">Services</Link> |
         <Link to="/speakers">Speakers</Link>
     </nav>

--- a/src/pages/SessionsSchedule.tsx
+++ b/src/pages/SessionsSchedule.tsx
@@ -2,29 +2,29 @@ import React, { useContext, useMemo, useState } from "react";
 import groupBy from "lodash.groupby";
 import { SessionTable } from "../components/SessionTable";
 import { EventContext } from "../context/EventContext";
-import { useEvents } from "../queries/schedule";
+import { useSessions } from "../queries/schedule";
 
-export const EventsSchedule: React.FC = () => {
+export const SessionsSchedule: React.FC = () => {
     const [filter, setFilter] = useState("");
 
     const domain = useContext(EventContext);
-    const eventsQuery = useEvents(domain, filter);
-    const events = eventsQuery.events ?? [];
+    const sessionsQuery = useSessions(domain, filter);
+    const sessions = sessionsQuery.sessions ?? [];
 
     const dateFormatter = new Intl.DateTimeFormat(undefined, {
         dateStyle: "full"
     });
 
-    const eventsByDate = useMemo(
-        () => groupBy(events, event => dateFormatter.format(new Date(event.startsAt))),
-        [events]
+    const sessionsByDate = useMemo(
+        () => groupBy(sessions, event => dateFormatter.format(new Date(event.startsAt))),
+        [sessions]
     );
 
-    if (eventsQuery.isLoading) {
+    if (sessionsQuery.isLoading) {
         return <div>Loading&hellip;</div>;
     }
 
-    if (eventsQuery.isError) {
+    if (sessionsQuery.isError) {
         return <div>oh no :(</div>;
     }
 
@@ -34,7 +34,7 @@ export const EventsSchedule: React.FC = () => {
             Search:
             <input type="search" value={filter} onChange={e => setFilter(e.target.value)}/>
         </label>
-        {Object.entries(eventsByDate).map(([date, dateEvents]) => <div key={date}>
+        {Object.entries(sessionsByDate).map(([date, dateEvents]) => <div key={date}>
             <h2>{date}</h2>
             <SessionTable sessions={dateEvents} />
         </div>)}

--- a/src/queries/schedule.ts
+++ b/src/queries/schedule.ts
@@ -6,18 +6,18 @@ import { Session } from "../models/session";
 export const useSchedule = (domain: string) =>
     useQuery<Schedule>([domain, "schedule"]);
 
-const filterEvent = (event: Session, filter?: string) =>
+const filterSession = (session: Session, filter?: string) =>
     filter === undefined || filter === ""
-    || event.title.toLocaleLowerCase().includes(filter.toLocaleLowerCase());
+    || session.title.toLocaleLowerCase().includes(filter.toLocaleLowerCase());
 
-export const useEvents = (domain: string, filter?: string) => {
+export const useSessions = (domain: string, filter?: string) => {
     const schedule = useSchedule(domain);
 
-    const events = useMemo(() => schedule.data?.sessions.filter(
-        session => !session.isServiceSession && filterEvent(session, filter)
+    const sessions = useMemo(() => schedule.data?.sessions.filter(
+        session => !session.isServiceSession && filterSession(session, filter)
     ), [schedule.data, filter]);
 
-    return { ...schedule, events }
+    return { ...schedule, sessions }
 }
 
 export const useServices = (domain: string) => {


### PR DESCRIPTION
"Event" meant two things until now. Cons were events, and sessions were events too. Whoops.

Resolves #1